### PR TITLE
Add script which calls factory-reset on a remote device [REVPI-2774]

### DIFF
--- a/worker/revpi_factory_reset.sh
+++ b/worker/revpi_factory_reset.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+SSH_HOST_RPI=$1
+DEVICE_TYPE=$2
+DEVICE_SERIAL=$3
+DEVICE_MAC=$4
+
+echo "$SSH_HOST_RPI"
+echo "$DEVICE_TYPE"
+echo "$DEVICE_SERIAL"
+echo "$DEVICE_MAC"
+
+# wait for the device to fully reboot
+while ! ping -c 1 "$SSH_HOST_RPI" > /dev/null 2>&1; do 
+	sleep 1; 
+done
+
+# let us wait for another 2 seconds
+sleep 2
+
+# now do the factory reset on the DuT and reboot it afterwards
+ssh -i /sshkey/lava_worker_ed25519 -o PasswordAuthentication=no -o StrictHostKeyChecking=no root@"$SSH_HOST_RPI" /usr/sbin/revpi-factory-reset "$DEVICE_TYPE" "$DEVICE_SERIAL" "$DEVICE_MAC"
+ssh -i /sshkey/lava_worker_ed25519 -o PasswordAuthentication=no -o StrictHostKeyChecking=no root@"$SSH_HOST_RPI" reboot
+
+exit 0
+


### PR DESCRIPTION
When a new image is deployed on a RevPi through LAVA, the device needs a factory-reset with serial number, device type and mac address. As the revpi might not be available when this script is started from LAVA, we wait for the device until it is discoverable on the network. One could surely make this with an oneliner in the LAVA user_commands, but this solution is more readable and expendable.

To work correctly, the script needs four parameters, first the hostname of the device, then the device type, then a serial number and the last parameter is the mac address for the RevPi.

Signed-off-by: Frank Erdrich <f.erdrich@kunbus.com>